### PR TITLE
Verbs clarification

### DIFF
--- a/assignment-1/text-samples/verbs-simple.txt
+++ b/assignment-1/text-samples/verbs-simple.txt
@@ -2,6 +2,8 @@ This is
 stoicism
 in the face of
 being in
-a tough spot
-is it?
-missing
+a tough spot.
+
+IS IT? HOW DO YOU FEEL?
+
+Is anything missing?

--- a/assignment-1/text-samples/verbs.txt
+++ b/assignment-1/text-samples/verbs.txt
@@ -1,1 +1,18 @@
-Lisa was sitting by the window, lost in thought. "What am I doing with my life?" she wondered. She had been working tirelessly, but the results were yet to be seen. People are often blinded by what they think they should do, she thought. She realized she could be doing something more fulfilling. When she had been younger, her dreams were vivid and endless. But time had a way of being unkind to dreams. "Will I ever find my true path?" she asked herself. She decided she would go wherever her passion leads, no longer being confined by the mundane. And so, her journey began, full of hope and uncertainty.
+Lisa was sitting by the window, lost in thought. .
+
+"What am I doing with my life?" she wondered.
+
+She had been working tirelessly, but the results were yet to be seen.
+
+"People are often blinded by what they think they should do", she thought.
+
+She realized she could be doing something more fulfilling.
+When she had been younger, her dreams were vivid and endless. 
+But time had a way of being unkind to dreams.
+
+"Will I ever find my true path?" she asked herself.
+
+She decided she would go wherever her passion leads, no longer being confined by the mundane. 
+And so, her journey began, full of hope and uncertainty. 
+
+And a red hibiscus in hand.

--- a/assignment-1/verbs.l
+++ b/assignment-1/verbs.l
@@ -16,9 +16,12 @@ void clean_verb(char *s, char *output);
 void print_header();
 
 int verb_count = 0;
+
+
+// The ?:i in the VERB pattern tells it to ignore case such that Is, IS, is, iS etc., will be matched.
 %}
 
-VERB (is|am|are|were|was|be|being|been|do|does|did|will|would|should|can|could|has|have|had|go)
+VERB (?i:is|am|are|were|was|be|being|been|do|does|did|will|would|should|can|could|has|have|had|go)
 WHITESPACE ([ |\t|\n])
 %%
 (^{VERB}{WHITESPACE}|{WHITESPACE}{VERB}{WHITESPACE}) { 

--- a/assignment-1/verbs.l
+++ b/assignment-1/verbs.l
@@ -1,14 +1,34 @@
 %{
 #include "token.h"
+#include <ctype.h>
 #include <string.h>
+
+// The longest verb in the list is "should" with 6 characters
+#define MAX_VERB_LENGTH 6
+
+/** Stores current matched token after removal of whitespace characters by `clean_verb`
+    The array is defined to have length MAX_VERB_LENGTH + 1, 
+    to allow for the string termination character '\0'.
+*/
+char current_result[MAX_VERB_LENGTH + 1];
+
+void clean_verb(char *s, char *output);
+void print_header();
+
+int verb_count = 0;
 %}
 
 VERB (is|am|are|were|was|be|being|been|do|does|did|will|would|should|can|could|has|have|had|go)
 WHITESPACE ([ |\t|\n])
-LETTER [a-zA-Z]
-
 %%
-(^{VERB}{WHITESPACE}|{WHITESPACE}{VERB}{WHITESPACE}) { return TOKEN_VERB; }
+(^{VERB}{WHITESPACE}|{WHITESPACE}+{VERB}{WHITESPACE}+) { 
+    clean_verb(yytext, current_result);
+
+    int at_end_of_line = yytext[strlen(yytext) - 1] == '\n';
+
+    printf("%-d\t%-s\n", at_end_of_line ? yylineno - 1 : yylineno, current_result);
+    verb_count++; 
+}
 \n ;
 . ;
 %%
@@ -29,19 +49,38 @@ int main(int argc, char **argv)
         printf("Could not open file: %s!\n", file_name);
         return 1;
     }
-    
-    while (1) {
-        token_t token = yylex();
-        if (token == TOKEN_EOF)
-            break;
-        
-        if (token == TOKEN_VERB) {
-            printf("verb: %s, lineno: %d\n", yytext, yylineno);
-        }
-    }
+
+    print_header();
+
+    yylex();
+    printf("\nNumber of verbs recognized: %d\n", verb_count);
     fclose(yyin);
 
     return 0;
+}
+
+void print_header() {
+    printf("Verb recognizer\n");
+    printf("---------------\n\n");
+    printf("line\tverb\n");
+    printf("----\t----\n");
+}
+
+/** Copies the letters of the verb in s into output without whitespace characters e.g '\t' or '\n'. */
+void clean_verb(char *s, char *output) {
+    char *copy = s;
+
+    int i = 0;
+
+    while (*copy != '\0') {
+        if (!isspace(*copy)) {
+            output[i] = *copy;
+            i += 1;
+        }
+        copy += 1;
+    }
+
+    output[i] = '\0';
 }
 
 int yywrap() { return 1; }

--- a/assignment-1/verbs.l
+++ b/assignment-1/verbs.l
@@ -1,7 +1,6 @@
 %{
-#include "token.h"
-#include <ctype.h>
-#include <string.h>
+#include <ctype.h>  // For `isspace`
+#include <string.h> // For `strlen` 
 
 // The longest verb in the list is "should" with 6 characters
 #define MAX_VERB_LENGTH 6
@@ -12,11 +11,11 @@
 */
 char current_result[MAX_VERB_LENGTH + 1];
 
+/** Copies the letters of the verb in s into output without whitespace characters e.g '\t' or '\n'. */
 void clean_verb(char *s, char *output);
 void print_header();
 
 int verb_count = 0;
-
 
 // The ?:i in the VERB pattern tells it to ignore case such that Is, IS, is, iS etc., will be matched.
 %}
@@ -26,10 +25,16 @@ WHITESPACE ([ |\t|\n])
 %%
 (^{VERB}{WHITESPACE}|{WHITESPACE}{VERB}{WHITESPACE}) { 
     clean_verb(yytext, current_result);
+    int at_end_of_line = yytext[strlen(yytext) - 1] == '\n';  // Result will be either 1 (True) or 0 (false)
 
-    int at_end_of_line = yytext[strlen(yytext) - 1] == '\n';
+    // yylineno is increased when a "\n" is encountered, so
+    // the actual matched line will be 1 more than the actual line if 
+    // a verb that occurs at the end of a line is encountered.
+    // The arithmetic here accounts for the above behaviour, and finds the appropriate
+    // matched line.
+    int matched_line = at_end_of_line ? yylineno - 1 : yylineno;
 
-    printf("%-d\t%-s\n", at_end_of_line ? yylineno - 1 : yylineno, current_result);
+    printf("%-d\t%-s\n", matched_line, current_result);
     verb_count++; 
 }
 \n ;
@@ -69,7 +74,6 @@ void print_header() {
     printf("----\t----\n");
 }
 
-/** Copies the letters of the verb in s into output without whitespace characters e.g '\t' or '\n'. */
 void clean_verb(char *s, char *output) {
     char *copy = s;
 

--- a/assignment-1/verbs.l
+++ b/assignment-1/verbs.l
@@ -21,7 +21,7 @@ int verb_count = 0;
 VERB (is|am|are|were|was|be|being|been|do|does|did|will|would|should|can|could|has|have|had|go)
 WHITESPACE ([ |\t|\n])
 %%
-(^{VERB}{WHITESPACE}|{WHITESPACE}+{VERB}{WHITESPACE}+) { 
+(^{VERB}{WHITESPACE}|{WHITESPACE}{VERB}{WHITESPACE}) { 
     clean_verb(yytext, current_result);
 
     int at_end_of_line = yytext[strlen(yytext) - 1] == '\n';


### PR DESCRIPTION
The changes to `verbs.l` are made to make the printed output look cleaner and to make the C code present in the specification easier to understand (through comments). "cleaner" means that new lines and spaces are handled correctly, such that the output looks organized.

Also, cleaning the output (handling new lines especially) allowed for the story in `verbs-simple.txt` to be spread out over multiple paragraphs.

The regular expressions have remained untouched, except for the `?i:` appended to the beginning of the regular expression for recognizing the verbs added to allow for case-insensitive verb recognition (e.g. is, Is, IS, or iS). `verbs-simple.txt` has been modified to test this case-insesitivity.